### PR TITLE
Document the somewhat surprising behavior of the optional capture groups.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,11 +627,17 @@ impl Drop for Pcre {
 
 impl<'a> Match<'a> {
     /// Returns the start index within the subject string of capture group `n`.
+    ///
+    /// If the capture group is present in the pattern but wasn't captured then it's start will be `usize::max_value()`.
+    /// Happens with the optional groups, `/(optional)?/`.
     pub fn group_start(&self, n: usize) -> usize {
         self.partial_ovector[(n * 2) as usize] as usize
     }
 
     /// Returns the end index within the subject string of capture group `n`.
+    ///
+    /// If the capture group is present in the pattern but wasn't captured then it's end will be `usize::max_value()`.
+    /// Happens with the optional groups, `/(optional)?/`.
     pub fn group_end(&self, n: usize) -> usize {
         self.partial_ovector[(n * 2 + 1) as usize] as usize
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,7 +628,7 @@ impl Drop for Pcre {
 impl<'a> Match<'a> {
     /// Returns the start index within the subject string of capture group `n`.
     ///
-    /// If the capture group is present in the pattern but wasn't captured then it's start will be `usize::max_value()`.
+    /// If the capture group is present in the pattern but wasn't captured then the start of it will be `usize::max_value()`.
     /// Happens with the optional groups, `/(optional)?/`.
     pub fn group_start(&self, n: usize) -> usize {
         self.partial_ovector[(n * 2) as usize] as usize
@@ -636,7 +636,7 @@ impl<'a> Match<'a> {
 
     /// Returns the end index within the subject string of capture group `n`.
     ///
-    /// If the capture group is present in the pattern but wasn't captured then it's end will be `usize::max_value()`.
+    /// If the capture group is present in the pattern but wasn't captured then the end of it will be `usize::max_value()`.
     /// Happens with the optional groups, `/(optional)?/`.
     pub fn group_end(&self, n: usize) -> usize {
         self.partial_ovector[(n * 2 + 1) as usize] as usize

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -169,3 +169,15 @@ fn test_extra_mark() {
     // and the marked value should be B
     assert_eq!(re.mark().unwrap(), "B");
 }
+
+#[test]
+fn test_optional_capture() {
+    let mut re = Pcre::compile("(foo)?bar").unwrap();
+    let subject = "bar";
+    let m1 = re.exec(subject).unwrap();
+    assert!(m1.group_start(0) == 0 && m1.group_end(0) == 3 && m1.group_len(0) == 3);  // bar
+    assert_eq!(m1.group_len(1), 0);
+    // That might come out as a surprise.
+    assert_eq!(m1.group_start(1), usize::max_value());  // c_int -1
+    assert_eq!(m1.group_end(1), usize::max_value());  // c_int -1
+}


### PR DESCRIPTION
I thought it was a bug.
Took me a trip to the code and writing a unit test to figure out it was the -1 in disguise.