### PR TITLE
Allow the `Match` to be temporary.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -650,7 +650,7 @@ impl<'a> Match<'a> {
 
     /// Returns the substring for capture group `n` as a slice.
     #[inline]
-    pub fn group(&'a self, n: usize) -> &'a str {
+    pub fn group(&self, n: usize) -> &'a str {
         let group_offsets = &self.partial_ovector[((n * 2) as usize)..];
         let start = group_offsets[0];
         let end = group_offsets[1];


### PR DESCRIPTION
Captured groups must be lifetime-bound to the matched string but not to the `Match` itself.
cf. http://doc.rust-lang.org/regex/regex/struct.Captures.html#method.at