### PR TITLE
Enum cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use std::vec::{Vec};
 
 mod detail;
 
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum CompileOption {
     Caseless = 0x00000001,
     Multiline = 0x00000002,
@@ -48,7 +48,7 @@ pub enum CompileOption {
     Ucp = 0x20000000
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum ExecOption {
     ExecAnchored = 0x00000010,
     ExecNotBol = 0x00000080,
@@ -72,7 +72,7 @@ pub const ExecPartial: ExecOption = ExecOption::ExecPartialSoft;
 #[allow(non_upper_case_globals)]
 pub const ExecNoStartOptimize: ExecOption = ExecOption::ExecNoStartOptimise;
 
-#[derive(Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum StudyOption {
     StudyJitCompile = 0x0001,
     StudyJitPartialSoftCompile = 0x0002,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,15 @@ pub struct MatchIterator<'a, 'p> {
 
 }
 
+// Under normal circumstances, CLike would use std::transmute to convert
+// a u32 to the enum, and a simple cast to convert the enum to a u32.
+// This doesn't work here since the enum values match the ones expected
+// by libpcre (so that they can be folded together into the appropriate bitmask
+// before making the C calls).
+//
+// A better, more efficient solution might be to use the bitflags macro instead.
+// (see https://doc.rust-lang.org/bitflags/bitflags/macro.bitflags!.html)
+
 impl CLike for CompileOption {
     unsafe fn from_u32(n: u32) -> CompileOption {
         use CompileOption::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,6 @@ pub enum ExecOption {
     ExecNotEmptyAtStart = 0x10000000
 }
 
-#[allow(non_upper_case_globals)]
-pub const ExecPartial: ExecOption = ExecOption::ExecPartialSoft;
-#[allow(non_upper_case_globals)]
-pub const ExecNoStartOptimize: ExecOption = ExecOption::ExecNoStartOptimise;
-
 #[derive(Copy, Clone, Debug)]
 pub enum StudyOption {
     StudyJitCompile = 0x0001,


### PR DESCRIPTION
Currently, this just adds `Copy` and `Debug` to the enums and removes a couple of consts (Is there a reason `ExecPartial` and `ExecNoStartOptimize` were set apart from the rest of the `ExecOption`s?)

If it's alright with everyone, I'd like to switch from using `enum-set` to the [bitflags! macro](https://doc.rust-lang.org/bitflags/bitflags/macro.bitflags!.html). The former requires `rust-pcre` to do a lot of legwork, both in the unorthodox implementations of `to_u32` and `from_u32`, and in the use of `fold` to reconstitute the bitfield when calling `libpcre` functions. The latter seems to be a much more natural (and possibly performant) fit.
