### PR TITLE
Make matches()/exec() work with non-mut pcre

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ impl Pcre {
     /// If a regular expression will be used often, it might be worth studying it to possibly
     /// speed up matching. See the [study()](#method.study) method.
     #[inline]
-    pub fn exec<'a, 'p>(&'p mut self, subject: &'a str) -> Option<Match<'a>> {
+    pub fn exec<'a, 'p>(&'p self, subject: &'a str) -> Option<Match<'a>> {
         self.exec_from(subject, 0)
     }
 
@@ -411,7 +411,7 @@ impl Pcre {
     /// If a regular expression will be used often, it might be worth studying it to possibly
     /// speed up matching. See the [study()](#method.study) method.
     #[inline]
-    pub fn exec_from<'a, 'p>(&'p mut self, subject: &'a str, startoffset: usize) -> Option<Match<'a>> {
+    pub fn exec_from<'a, 'p>(&'p self, subject: &'a str, startoffset: usize) -> Option<Match<'a>> {
         let no_options: EnumSet<ExecOption> = EnumSet::new();
         self.exec_from_with_options(subject, startoffset, &no_options)
     }
@@ -436,7 +436,7 @@ impl Pcre {
     /// If a regular expression will be used often, it might be worth studying it to possibly
     /// speed up matching. See the [study()](#method.study) method.
     #[inline]
-    pub fn exec_from_with_options<'a, 'p>(&'p mut self, subject: &'a str, startoffset: usize, options: &EnumSet<ExecOption>) -> Option<Match<'a>> {
+    pub fn exec_from_with_options<'a, 'p>(&'p self, subject: &'a str, startoffset: usize, options: &EnumSet<ExecOption>) -> Option<Match<'a>> {
         let ovecsize = (self.capture_count_ + 1) * 3;
         let mut ovector = vec![0 as c_int; ovecsize as usize];
 
@@ -496,7 +496,7 @@ impl Pcre {
     /// # Argument
     /// * `subject` - The subject string.
     #[inline]
-    pub fn matches<'a, 'p>(&'p mut self, subject: &'a str) -> MatchIterator<'a, 'p> {
+    pub fn matches<'a, 'p>(&'p self, subject: &'a str) -> MatchIterator<'a, 'p> {
         let no_options: EnumSet<ExecOption> = EnumSet::new();
         self.matches_with_options(subject, &no_options)
     }
@@ -509,7 +509,7 @@ impl Pcre {
     /// * `options` - Bitwise-OR'd matching options. See the libpcre manpages, `man 3 pcre_exec`,
     ///   for more information.
     #[inline]
-    pub fn matches_with_options<'a, 'p>(&'p mut self, subject: &'a str, options: &EnumSet<ExecOption>) -> MatchIterator<'a, 'p> {
+    pub fn matches_with_options<'a, 'p>(&'p self, subject: &'a str, options: &EnumSet<ExecOption>) -> MatchIterator<'a, 'p> {
         unsafe {
             let ovecsize = (self.capture_count_ + 1) * 3;
             MatchIterator {


### PR DESCRIPTION
It doesn't look like these methods need to take a mutable reference -- though I'm new to rust so I can't really tell for sure... Am I missing something?  (It still builds fine and all tests still pass.) 
